### PR TITLE
Allow specification of filename column

### DIFF
--- a/lib/csv_to_html/cli.rb
+++ b/lib/csv_to_html/cli.rb
@@ -13,16 +13,21 @@ module CsvToHtml
          'Build files from the ERB template and CSV file'
     method_option :delimiter, aliases: '-d', default: ',',
                               desc: 'Set CSV delimiter'
+    method_option :'filename-col', aliases: '-c',
+                                   desc: 'Set column to use as filename'
     def build(erb_path, csv_path, output_path)
       validate_input(erb_path, csv_path, output_path)
 
       erb = ERB.new File.read(erb_path)
 
       csv_options = { headers: true, col_sep: options[:delimiter] }
+      filename_col = options[:'filename-col']
 
       CSV.foreach(csv_path, csv_options).with_index(1) do |row, i|
-        row_output = CsvToHtml::Row.new(row).render(erb)
-        File.write "#{output_path}/#{i}.html", row_output
+        row = CsvToHtml::Row.new(row)
+        filename = filename_col ? row.send(filename_col) : i
+
+        File.write "#{output_path}/#{filename}.html", row.render(erb)
       end
     end
 

--- a/spec/lib/csv_to_html/cli_spec.rb
+++ b/spec/lib/csv_to_html/cli_spec.rb
@@ -88,6 +88,20 @@ RSpec.describe CsvToHtml::CLI do
             File.read("#{fixtures_path}/output/1.html")
         end
       end
+
+      context 'Filename column' do
+        before do
+          subject.invoke(:build, [erb_path, csv_path, output_path],
+                         'filename-col': 'name')
+        end
+
+        it 'uses filename_col as filename' do
+          expect(file_list.size).to eq 3
+          expect(file_list).to include "#{output_path}/Paul.html"
+          expect(file_list).to include "#{output_path}/John.html"
+          expect(file_list).to include "#{output_path}/Anne.html"
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Feat

## What is the current behavior? (You can also link to an open issue here)

Output files are always named as `row_number.html`.

## What is the new behavior (if this is a feature change)?

Allow specification of a column to use as filename. If left blank, uses
previous default.

## How can one test the new behavior?

bundle exec rspec

## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

Nope

## Other information: