### PR TITLE
Use File.join to create paths

### DIFF
--- a/lib/csv_to_html/cli.rb
+++ b/lib/csv_to_html/cli.rb
@@ -27,7 +27,7 @@ module CsvToHtml
         row = CsvToHtml::Row.new(row)
         filename = filename_col ? row.send(filename_col) : i
 
-        File.write "#{output_path}/#{filename}.html", row.render(erb)
+        File.write File.join(output_path, "#{filename}.html"), row.render(erb)
       end
     end
 

--- a/spec/lib/csv_to_html/cli_spec.rb
+++ b/spec/lib/csv_to_html/cli_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe CsvToHtml::CLI do
 
   describe '#build' do
     let!(:fixtures_path) { File.expand_path '../../fixtures', __dir__ }
-    let!(:erb_path) { "#{fixtures_path}/person.html.erb" }
-    let!(:csv_path) { "#{fixtures_path}/people.csv" }
+    let!(:erb_path) { File.join(fixtures_path, 'person.html.erb') }
+    let!(:csv_path) { File.join(fixtures_path, 'people.csv') }
 
     context 'Inexistent files' do
       let!(:wrong_erb_path) { 'spec/this/is/not/a/file' }
@@ -44,8 +44,8 @@ RSpec.describe CsvToHtml::CLI do
     context 'Existent files' do
       include FakeFS::SpecHelpers
 
-      let!(:output_path) { '/home/output' }
-      let(:file_list) { Dir.glob "#{output_path}/*" }
+      let!(:output_path) { File.join('/', 'home', 'output') }
+      let(:file_list) { Dir.glob File.join(output_path, '*') }
 
       before do
         FakeFS::FileSystem.clone fixtures_path
@@ -59,15 +59,16 @@ RSpec.describe CsvToHtml::CLI do
 
         it 'creates files in desired path' do
           expect(file_list.size).to eq 3
-          expect(file_list).to include "#{output_path}/1.html"
-          expect(file_list).to include "#{output_path}/2.html"
-          expect(file_list).to include "#{output_path}/3.html"
+          expect(file_list).to include File.join(output_path, '1.html')
+          expect(file_list).to include File.join(output_path, '2.html')
+          expect(file_list).to include File.join(output_path, '3.html')
         end
 
         it 'generates correct output' do
           file_list.each do |output|
             expect(File.read(output)).to eq \
-              File.read("#{fixtures_path}/output/#{File.basename(output)}")
+              File.read File.join(fixtures_path, 'output',
+                                  File.basename(output))
           end
         end
       end
@@ -84,8 +85,8 @@ RSpec.describe CsvToHtml::CLI do
 
         it 'reads the csv with specified delimiter' do
           expect(file_list.size).to eq 1
-          expect(File.read("#{output_path}/1.html")).to eq \
-            File.read("#{fixtures_path}/output/1.html")
+          expect(File.read(File.join(output_path, '1.html'))).to eq \
+            File.read(File.join(fixtures_path, 'output', '1.html'))
         end
       end
 
@@ -97,9 +98,9 @@ RSpec.describe CsvToHtml::CLI do
 
         it 'uses filename_col as filename' do
           expect(file_list.size).to eq 3
-          expect(file_list).to include "#{output_path}/Paul.html"
-          expect(file_list).to include "#{output_path}/John.html"
-          expect(file_list).to include "#{output_path}/Anne.html"
+          expect(file_list).to include File.join(output_path, 'Paul.html')
+          expect(file_list).to include File.join(output_path, 'John.html')
+          expect(file_list).to include File.join(output_path, 'Anne.html')
         end
       end
     end


### PR DESCRIPTION
## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Fix

## What is the current behavior? (You can also link to an open issue here)

Make file paths from strings, which could lead to `//` and such.

## What is the new behavior (if this is a feature change)?

Make file paths with `File.join`, including in tests for consistency.

## How can one test the new behavior?

bundle exec rspec

## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

Nope

## Other information: